### PR TITLE
Gère les redimensionnements

### DIFF
--- a/src/input_processing.py
+++ b/src/input_processing.py
@@ -8,6 +8,7 @@ if sys.platform == "win32":
     from terminal import MockPyINPUT_RECORDType
 else:
     import fcntl
+    import signal
 import os
 import terminal
 from data_types import Coord
@@ -35,7 +36,7 @@ def on_key(info: KeyInfo, term_info: TerminalInfoProxy):
 def on_arrow(info: ArrowInfo):
     print(info, end="\n\r")
 def on_resize():
-    print(os.get_terminal_size())
+    print(os.get_terminal_size(), end="\n\r")
 
 if sys.platform == "win32":
     def parse_windows_mouse_event(event: MockPyINPUT_RECORDType, last_click: MouseClick | None) -> MouseInfo:
@@ -230,10 +231,14 @@ else:
         def __exit__(self, *_):
             fcntl.fcntl(self.fd, fcntl.F_SETFL, self.orig_fl)
 
+def sigwich_handler(signum, frame):
+    on_resize()
 
 def listen_to_input(term_info: TerminalInfoProxy):
     # On réouvre sys.stdin car il est automatiquement fermé lors de la création d'un nouveau processus
     sys.stdin = os.fdopen(0)
+
+    signal.signal(signal.SIGWINCH, sigwich_handler)
 
     # Ces valeurs seront changées à partir de la première intéraction
     previous_mouse_info: MouseInfo | None = None

--- a/src/input_processing.py
+++ b/src/input_processing.py
@@ -3,8 +3,9 @@
 
 import sys
 if sys.platform == "win32":
-    import win32console, win32con
-    import scale_win_console
+    import win32console
+    import win32con
+    from terminal import scale_win_console
     from terminal import MockPyINPUT_RECORDType
 else:
     import fcntl
@@ -238,7 +239,8 @@ def listen_to_input(term_info: TerminalInfoProxy):
     # On réouvre sys.stdin car il est automatiquement fermé lors de la création d'un nouveau processus
     sys.stdin = os.fdopen(0)
 
-    signal.signal(signal.SIGWINCH, sigwich_handler)
+    if sys.platform != "win32":
+        signal.signal(signal.SIGWINCH, sigwich_handler)
 
     # Ces valeurs seront changées à partir de la première intéraction
     previous_mouse_info: MouseInfo | None = None

--- a/src/input_processing.py
+++ b/src/input_processing.py
@@ -20,6 +20,7 @@ def on_key(info: KeyInfo, term_info: TerminalInfoProxy):
         terminal.reset(term_info)
         sys.exit(0)
 
+    # TODO : zoomer DANS la console sans l'agrandir
     if (info.char == b'=' or info.char == b'+') and info.key_flag & KeyFlags.ALT:
         scale_win_console(1)
         on_resize()

--- a/src/input_processing.py
+++ b/src/input_processing.py
@@ -4,13 +4,14 @@
 import sys
 if sys.platform == "win32":
     import win32console, win32con
+    import scale_win_console
     from terminal import MockPyINPUT_RECORDType
 else:
     import fcntl
 import os
 import terminal
 from data_types import Coord
-from terminal import TerminalInfoProxy, scale_win_console
+from terminal import TerminalInfoProxy
 from input_properties import *
 
 def on_mouse(info: MouseInfo):
@@ -21,12 +22,13 @@ def on_key(info: KeyInfo, term_info: TerminalInfoProxy):
         sys.exit(0)
 
     # TODO : zoomer DANS la console sans l'agrandir
-    if (info.char == b'=' or info.char == b'+') and info.key_flag & KeyFlags.ALT:
-        scale_win_console(1)
-        on_resize()
-    if info.char == b'-' and info.key_flag & KeyFlags.ALT:
-        scale_win_console(-1)
-        on_resize()
+    if sys.platform == "win32":
+        if (info.char == b'=' or info.char == b'+') and info.key_flag & KeyFlags.ALT:
+            scale_win_console(1)
+            on_resize()
+        if info.char == b'-' and info.key_flag & KeyFlags.ALT:
+            scale_win_console(-1)
+            on_resize()
     # TODO : Créer un fichier contenant toutes les définitions de caractères spéciaux
     print(info, end="\n\r")
 


### PR DESCRIPTION
Détecte le redimensionnement de la fenêtre / zoom du terminal via 'on_resize'.
À noter toute fois que le zoom sur l'invite de commande Windows est assez particulier et ne peut être géré comme sur Linux.